### PR TITLE
feat(runtime) add telemetry package to runtime

### DIFF
--- a/packages/runtime/src/runtime/telemetry/analytics-service.ts
+++ b/packages/runtime/src/runtime/telemetry/analytics-service.ts
@@ -1,0 +1,52 @@
+import { gaId, machineUUID } from 'common/stats'
+import { TYPES } from 'core/app/types'
+import { ConfigProvider } from 'core/config'
+import { inject, injectable, postConstruct } from 'inversify'
+import { AppLifecycle, AppLifecycleEvents } from 'lifecycle'
+import ua, { Visitor } from 'universal-analytics'
+
+@injectable()
+export class AnalyticsService {
+  private _visitor: Visitor | undefined
+  private _queued: Function[] = []
+  private _sendUsageStats!: boolean
+
+  constructor(@inject(TYPES.ConfigProvider) private configProvider: ConfigProvider) {}
+
+  @postConstruct()
+  public async init() {
+    await AppLifecycle.waitFor(AppLifecycleEvents.CONFIGURATION_LOADED)
+    const botpressConfig = await this.configProvider.getBotpressConfig()
+    this._sendUsageStats = botpressConfig.sendUsageStats
+
+    const uuid = await machineUUID()
+    this._visitor = ua(gaId, uuid, { strictCidFormat: false })
+    this._queued.forEach(event => event())
+    this._queued = []
+  }
+
+  /**
+   * Send an event to Google Analytics
+   * @param category Typically the object that was interacted with (e.g. 'Video')
+   * @param action The type of interaction (e.g. 'play')
+   * @param label Useful for categorizing events (e.g. 'Fall Campaign')
+   * @param value A numeric value associated with the event (e.g. 42)
+   */
+  public track(category: string, action: string, label: string = '', value: string | number = '') {
+    if (!this._sendUsageStats) {
+      return
+    }
+
+    // Queue events while the visitor is not available
+    if (!this._visitor) {
+      this._queued.push(() => this.track(category, action, label, value))
+      return
+    }
+
+    this._visitor.event(category, action, label, value, () => this._handleError).send()
+  }
+
+  private _handleError() {
+    // ignore
+  }
+}

--- a/packages/runtime/src/runtime/telemetry/index.ts
+++ b/packages/runtime/src/runtime/telemetry/index.ts
@@ -1,0 +1,5 @@
+export * from './stats-service'
+export * from './telemetry-repository'
+export * from './telemetry-router'
+export * from './stats/telemetry.inversify'
+export * from './analytics-service'

--- a/packages/runtime/src/runtime/telemetry/stats-service.ts
+++ b/packages/runtime/src/runtime/telemetry/stats-service.ts
@@ -1,0 +1,52 @@
+import { TYPES } from 'core/app/types'
+import { JobService } from 'core/distributed'
+import { inject, injectable } from 'inversify'
+import ms from 'ms'
+
+import { ActionsStats } from './stats/actions-stats'
+import { ConfigsStats } from './stats/configs-stats'
+import { HooksStats } from './stats/hooks-stats'
+import { LegacyStats } from './stats/legacy-stats'
+import { RolesStats } from './stats/roles-stats'
+import { SDKStats } from './stats/sdk-stats'
+import { UserStats } from './stats/user-stats'
+import { TelemetryRepository } from './telemetry-repository'
+
+const DB_REFRESH_LOCK = 'botpress:telemetryDB'
+const DB_REFRESH_INTERVAL = ms('15 minute')
+
+@injectable()
+export class StatsService {
+  constructor(
+    @inject(TYPES.JobService) private jobService: JobService,
+    @inject(TYPES.TelemetryRepository) private telemetryRepo: TelemetryRepository,
+    @inject(TYPES.ActionStats) private actionStats: ActionsStats,
+    @inject(TYPES.LegacyStats) private legacyStats: LegacyStats,
+    @inject(TYPES.RolesStats) private rolesStats: RolesStats,
+    @inject(TYPES.SDKStats) private sdkStats: SDKStats,
+    @inject(TYPES.HooksStats) private hooksStats: HooksStats,
+    @inject(TYPES.ConfigsStats) private configStats: ConfigsStats,
+    @inject(TYPES.UserStats) private userStats: UserStats
+  ) {}
+
+  public async start() {
+    this.actionStats.start()
+    this.legacyStats.start()
+    this.hooksStats.start()
+    this.configStats.start()
+    this.rolesStats.start()
+    this.sdkStats.start()
+    this.userStats.start()
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    this.refreshDB(DB_REFRESH_INTERVAL)
+
+    setInterval(this.refreshDB.bind(this, DB_REFRESH_INTERVAL), DB_REFRESH_INTERVAL)
+  }
+
+  private async refreshDB(interval: number) {
+    const lock = await this.jobService.acquireLock(DB_REFRESH_LOCK, interval - ms('1 minute'))
+    if (lock) {
+      await this.telemetryRepo.refreshAvailability()
+    }
+  }
+}

--- a/packages/runtime/src/runtime/telemetry/stats/actions-stats.ts
+++ b/packages/runtime/src/runtime/telemetry/stats/actions-stats.ts
@@ -1,0 +1,102 @@
+import { parseActionInstruction } from 'common/action'
+import { BUILTIN_MODULES } from 'common/defaults'
+import LicensingService from 'common/licensing-service'
+import { buildSchema, TelemetryEvent } from 'common/telemetry'
+import { BotService } from 'core/bots'
+import { GhostService } from 'core/bpfs'
+import Database from 'core/database'
+import { FlowService } from 'core/dialog'
+import { JobService } from 'core/distributed'
+import { calculateHash } from 'core/misc/utils'
+import { TYPES } from 'core/types'
+import { inject, injectable } from 'inversify'
+import _ from 'lodash'
+import ms from 'ms'
+
+import { TelemetryRepository } from '../telemetry-repository'
+import { TelemetryStats } from './telemetry-stats'
+
+interface RawFlow {
+  flowName: string
+  botID: string
+  actions: string[]
+}
+
+interface ParsedFlow {
+  flowName: string
+  botID: string
+  actions: {
+    actionName: string
+    params: any
+  }[]
+}
+
+@injectable()
+export class ActionsStats extends TelemetryStats {
+  protected interval: number
+  protected url: string
+  protected lock: string
+
+  constructor(
+    @inject(TYPES.GhostService) ghostService: GhostService,
+    @inject(TYPES.Database) database: Database,
+    @inject(TYPES.LicensingService) licenseService: LicensingService,
+    @inject(TYPES.JobService) jobService: JobService,
+    @inject(TYPES.TelemetryRepository) telemetryRepo: TelemetryRepository,
+    @inject(TYPES.FlowService) private flowService: FlowService
+  ) {
+    super(ghostService, database, licenseService, jobService, telemetryRepo)
+    this.url = process.TELEMETRY_URL
+    this.lock = 'botpress:telemetry-actions'
+    this.interval = ms('1d')
+  }
+
+  protected async getStats(): Promise<TelemetryEvent> {
+    return {
+      ...buildSchema(await this.getServerStats(), 'server'),
+      event_type: 'builtin_actions',
+      event_data: { schema: '1.0.0', flows: await this.getFlowsWithActions() }
+    }
+  }
+
+  private async getFlowsWithActions(): Promise<ParsedFlow[]> {
+    const botIds = BotService.getMountedBots()
+    const flows = _.flatten(
+      await Promise.map(botIds, async botID => {
+        const flowView = await this.flowService.forBot(botID).loadAll()
+        return flowView.map(flow => {
+          const { name } = flow
+          const actions = flow.nodes
+            .map(node => [...((node.onEnter as string[]) ?? []), ...((node.onReceive as string[]) ?? [])])
+            .reduce((acc, cur) => [...acc, ...cur], [])
+
+          return { flowName: name, botID, actions }
+        })
+      })
+    )
+    return flows.map(flow => this.parseFlow(flow)).filter(flow => flow.actions.length > 0)
+  }
+
+  private parseFlow(flow: RawFlow): ParsedFlow {
+    const actions = flow.actions
+      .map(action => parseActionInstruction(action))
+      .filter(action => BUILTIN_MODULES.includes(action.actionName.split('/')[0]))
+
+    return {
+      flowName: calculateHash(flow.flowName),
+      botID: calculateHash(flow.botID),
+      actions: actions.map(action => {
+        const actionName = action.actionName.split('/')[1]
+        try {
+          const params = JSON.parse(action.argsStr)
+          for (const key in params) {
+            params[key] = !!params[key] ? 1 : 0
+          }
+          return { actionName, params }
+        } catch (error) {
+          return { actionName, params: {} }
+        }
+      })
+    }
+  }
+}

--- a/packages/runtime/src/runtime/telemetry/stats/configs-stats.ts
+++ b/packages/runtime/src/runtime/telemetry/stats/configs-stats.ts
@@ -1,0 +1,185 @@
+import { BotDetails } from 'botpress/sdk'
+import { BUILTIN_MODULES } from 'common/defaults'
+import LicensingService from 'common/licensing-service'
+import { buildSchema, TelemetryEvent } from 'common/telemetry'
+import { BotService } from 'core/bots'
+import { GhostService } from 'core/bpfs'
+import { BotConfig, BotpressConfig, ConfigProvider } from 'core/config'
+import Database from 'core/database'
+import { JobService } from 'core/distributed'
+import { calculateHash } from 'core/misc/utils'
+import { ModuleLoader, ModuleConfig } from 'core/modules'
+import { TYPES } from 'core/types'
+import { inject, injectable } from 'inversify'
+import defaultJsonBuilder from 'json-schema-defaults'
+import _ from 'lodash'
+import ms from 'ms'
+
+import { TelemetryRepository } from '../telemetry-repository'
+import { DEFAULT, REDACTED, TelemetryStats } from './telemetry-stats'
+
+const SECRET_KEYS = [
+  'secret',
+  'pw',
+  'password',
+  'token',
+  'key',
+  'promoted_by',
+  'description',
+  'admins',
+  'email',
+  'connection',
+  'appId',
+  's3',
+  'cert',
+  'authstrategies',
+  'ducklingurl',
+  'languagesources'
+]
+
+interface BotConfigEvent {
+  botId: string
+  botConfig: BotConfig
+}
+
+interface ModuleConfigEvent {
+  botId: string
+  module: string
+  config: ModuleConfig
+}
+
+@injectable()
+export class ConfigsStats extends TelemetryStats {
+  protected interval: number
+  protected url: string
+  protected lock: string
+
+  constructor(
+    @inject(TYPES.GhostService) ghostService: GhostService,
+    @inject(TYPES.Database) database: Database,
+    @inject(TYPES.LicensingService) licenseService: LicensingService,
+    @inject(TYPES.JobService) jobService: JobService,
+    @inject(TYPES.TelemetryRepository) telemetryRepo: TelemetryRepository,
+    @inject(TYPES.BotService) private botService: BotService,
+    @inject(TYPES.ModuleLoader) private moduleLoader: ModuleLoader,
+    @inject(TYPES.ConfigProvider) private config: ConfigProvider
+  ) {
+    super(ghostService, database, licenseService, jobService, telemetryRepo)
+    this.url = process.TELEMETRY_URL
+    this.lock = 'botpress:telemetry-configs'
+    this.interval = ms('7d')
+  }
+
+  protected async getStats(): Promise<TelemetryEvent> {
+    const temp = {
+      ...buildSchema(await this.getServerStats(), 'server'),
+      event_type: 'configs',
+      event_data: {
+        schema: '1.0.0',
+        botConfigs: await this.getBotsConfigs(),
+        modulesConfigs: await this.getModulesConfigs(),
+        botpressConfig: await this.getBotpressConfig()
+      }
+    }
+    return temp
+  }
+
+  private obfuscateSecrets(config, defaultConfig): any {
+    return _.reduce(
+      config,
+      (res, value, key) => {
+        if (SECRET_KEYS.find(x => key.toLowerCase().includes(x))) {
+          res[key] = _.isEqual(config[key], defaultConfig?.[key] ?? {}) ? DEFAULT : REDACTED
+        } else if (!_.isArray(value) && _.isObject(value)) {
+          res[key] = this.obfuscateSecrets(value, defaultConfig?.[key] ?? {})
+        } else {
+          res[key] = value
+        }
+        return res
+      },
+      {}
+    )
+  }
+
+  private async fetchSchema(schemaName: string): Promise<any> {
+    try {
+      return this.ghostService.root().readFileAsObject('/', schemaName)
+    } catch (error) {
+      return {}
+    }
+  }
+
+  private async getBotpressConfig(): Promise<BotpressConfig> {
+    const botpressConfig = this.obfuscateModulesLocation(await this.config.getBotpressConfig())
+    const defaultConfig = defaultJsonBuilder(await this.fetchSchema('botpress.config.schema.json'))
+
+    return this.obfuscateSecrets(botpressConfig, defaultConfig)
+  }
+
+  private obfuscateModulesLocation(botpressConfig: BotpressConfig) {
+    const modules = botpressConfig.modules.map(module => {
+      if (BUILTIN_MODULES.includes(module.location.split('/').pop() || '')) {
+        return module
+      } else {
+        return { location: REDACTED, enabled: module.enabled }
+      }
+    })
+    return { ...botpressConfig, modules }
+  }
+
+  private async getModulesConfigs(): Promise<ModuleConfigEvent[]> {
+    const bots = BotService.getMountedBots()
+    const modules = _.intersection(BUILTIN_MODULES, Object.keys(process.LOADED_MODULES))
+
+    return (await Promise.map(modules, this.getConfigsByModule(bots)))
+      .reduce((acc, cur) => [...acc, ...cur])
+      .filter(moduleConfig => _.size(moduleConfig.config) > 0)
+  }
+
+  private getConfigsByModule(bots: string[]): (module: string) => Promise<ModuleConfigEvent[]> {
+    return async module => {
+      const defaultValue = await this.moduleLoader.configReader.loadFromDefaultValues(module)
+      return Promise.map(bots, this.getModuleConfigPerBot(module, defaultValue))
+    }
+  }
+
+  private getModuleConfigPerBot(module: string, defaultValue: any): (botId: any) => Promise<ModuleConfigEvent> {
+    return async botId => {
+      const runtimeValue = _.omit(await this.moduleLoader.configReader.getForBot(module, botId), '$schema')
+
+      return { module, botId: calculateHash(botId), config: this.obfuscateSecrets(runtimeValue, defaultValue) }
+    }
+  }
+
+  private async getBotsConfigs(): Promise<BotConfigEvent[]> {
+    const defaultConfig = defaultJsonBuilder(await this.fetchSchema('bot.config.schema.json'))
+    const bots = await this.botService.getBots()
+
+    return [...bots].reduce((acc: any[], bot) => {
+      const [botId, botConfig] = bot
+      return [...acc, { botId: calculateHash(botId), botConfig: this.formatBotConfig(botConfig, defaultConfig) }]
+    }, [])
+  }
+
+  private formatBotConfig(botConfig: BotConfig, defaultConfig): BotConfig {
+    return {
+      ...this.obfuscateSecrets(botConfig, defaultConfig),
+      details: this.formatBotDetails(botConfig.details),
+      id: calculateHash(botConfig.id),
+      name: calculateHash(botConfig.name)
+    }
+  }
+
+  private formatBotDetails(details: BotDetails): BotDetails {
+    const detailKeys = [
+      'website',
+      'phoneNumber',
+      'termsConditions',
+      'emailAddress',
+      'avatarUrl',
+      'coverPictureUrl',
+      'privacyPolicy'
+    ]
+    return detailKeys.reduce((acc, key) => ({ ...acc, [key]: details[key] ? REDACTED : DEFAULT }), {})
+  }
+}

--- a/packages/runtime/src/runtime/telemetry/stats/hooks-stats.ts
+++ b/packages/runtime/src/runtime/telemetry/stats/hooks-stats.ts
@@ -1,0 +1,97 @@
+import { BUILTIN_MODULES } from 'common/defaults'
+import LicensingService from 'common/licensing-service'
+import { buildSchema } from 'common/telemetry'
+import { BotService } from 'core/bots'
+import { GhostService } from 'core/bpfs'
+import Database from 'core/database'
+import { JobService } from 'core/distributed'
+import { calculateHash } from 'core/misc/utils'
+import { TYPES } from 'core/types'
+import { inject, injectable } from 'inversify'
+import _ from 'lodash'
+import ms from 'ms'
+
+import { TelemetryRepository } from '../telemetry-repository'
+import { TelemetryStats } from './telemetry-stats'
+
+export interface BotHooks {
+  botId: string
+  hooks: Hook[]
+}
+
+export interface Hook {
+  name: string
+  type: string
+  enabled: boolean
+  lifecycle: string
+  path?: string
+}
+
+export interface HookPayload {
+  perBots: BotHooks[]
+  global: Hook[]
+}
+
+export const getHooksLifecycle = async (ghostService: GhostService, hashBotId: boolean): Promise<HookPayload> => {
+  const botIds = BotService.getMountedBots()
+  const perBots = await Promise.map(botIds, async id => {
+    const botHooksPaths = await ghostService.forBot(id).directoryListing('/hooks', '*.js')
+    const lifecycles = parsePaths(botHooksPaths)
+    return { botId: hashBotId ? calculateHash(id) : id, hooks: lifecycles }
+  })
+  const globalHooksPaths = await ghostService.global().directoryListing('/hooks', '*.js')
+  const global = parsePaths(globalHooksPaths)
+
+  return { global, perBots }
+}
+
+const parsePaths = (paths: string[]): Hook[] => {
+  return paths.reduce((acc, curr) => {
+    const path = curr.split('/')
+    const lifecycle = path.shift() || ''
+    const hookName = path.pop()
+    const module = path.pop()
+    const isBuiltIn = !!(module && BUILTIN_MODULES.includes(module))
+    const { name, enabled } = parseHookName(hookName || '', isBuiltIn)
+
+    return [...acc, { name, lifecycle, enabled, type: isBuiltIn ? 'built-in' : 'custom', path: curr }]
+  }, [] as Hook[])
+}
+
+const parseHookName = (hookName: string, isBuiltIn: boolean) => {
+  const enabled = !hookName.startsWith('.')
+  const name = enabled ? hookName : hookName.substr(1)
+
+  return { name: isBuiltIn ? name : calculateHash(name), enabled }
+}
+
+@injectable()
+export class HooksStats extends TelemetryStats {
+  protected interval: number
+  protected url: string
+  protected lock: string
+
+  constructor(
+    @inject(TYPES.GhostService) ghostService: GhostService,
+    @inject(TYPES.Database) database: Database,
+    @inject(TYPES.LicensingService) licenseService: LicensingService,
+    @inject(TYPES.JobService) jobService: JobService,
+    @inject(TYPES.TelemetryRepository) telemetryRepo: TelemetryRepository
+  ) {
+    super(ghostService, database, licenseService, jobService, telemetryRepo)
+    this.url = process.TELEMETRY_URL
+    this.lock = 'botpress:telemetry-hooks'
+    this.interval = ms('1d')
+  }
+
+  protected async getStats() {
+    return {
+      ...buildSchema(await this.getServerStats(), 'server'),
+      event_type: 'hooks_lifecycle',
+      event_data: {
+        schema: '1.0.0',
+        lifeCycles: _.omit(await getHooksLifecycle(this.ghostService, true), 'path')
+      }
+    }
+  }
+}

--- a/packages/runtime/src/runtime/telemetry/stats/legacy-stats.ts
+++ b/packages/runtime/src/runtime/telemetry/stats/legacy-stats.ts
@@ -1,0 +1,186 @@
+import LicensingService from 'common/licensing-service'
+import { machineUUID } from 'common/stats'
+import { BotService } from 'core/bots'
+import { GhostService } from 'core/bpfs'
+import { CMSService } from 'core/cms'
+import { ConfigProvider } from 'core/config'
+import Database from 'core/database'
+import { JobService } from 'core/distributed'
+import { AuthService } from 'core/security'
+import { TYPES } from 'core/types'
+import { ChannelUserRepository, WorkspaceService } from 'core/users'
+import { inject, injectable } from 'inversify'
+import ms from 'ms'
+import os from 'os'
+import uuid from 'uuid'
+import yn from 'yn'
+
+import { TelemetryRepository } from '../telemetry-repository'
+import { TelemetryStats } from './telemetry-stats'
+
+@injectable()
+export class LegacyStats extends TelemetryStats {
+  protected interval: number
+  protected url: string
+  protected lock: string
+
+  constructor(
+    @inject(TYPES.GhostService) ghostService: GhostService,
+    @inject(TYPES.Database) database: Database,
+    @inject(TYPES.LicensingService) licenseService: LicensingService,
+    @inject(TYPES.JobService) jobService: JobService,
+    @inject(TYPES.TelemetryRepository) telemetryRepo: TelemetryRepository,
+    @inject(TYPES.ConfigProvider) private config: ConfigProvider,
+    @inject(TYPES.CMSService) private cmsService: CMSService,
+    @inject(TYPES.AuthService) private authService: AuthService,
+    @inject(TYPES.UserRepository) private userRepository: ChannelUserRepository,
+    @inject(TYPES.WorkspaceService) private workspaceService: WorkspaceService
+  ) {
+    super(ghostService, database, licenseService, jobService, telemetryRepo)
+    this.url = 'https://telemetry.botpress.io/ingest'
+    this.lock = 'botpress:telemetry-legacyStats'
+    this.interval = ms('1d')
+  }
+
+  protected async getStats() {
+    const config = await this.config.getBotpressConfig()
+
+    return {
+      schema: '1.0.0',
+      timestamp: new Date().toISOString(),
+      uuid: uuid.v4(),
+      server: await this.getServerStats(),
+      license: {
+        type: process.IS_PRO_ENABLED ? 'pro' : 'ce',
+        status: await this.getLicenseStatus(),
+        isProAvailable: process.IS_PRO_AVAILABLE,
+        showPoweredBy: config.showPoweredBy
+      },
+      bots: {
+        count: await this.getBotsCount()
+      },
+      workspaces: {
+        count: await this.getWorkspacesCount(),
+        pipelines: {
+          stages: {
+            count: await this.getPipelineStagesCount()
+          }
+        }
+      },
+      flows: {
+        count: await this.getFlowCount()
+      },
+      nlu: {
+        intents: {
+          count: await this.getIntentsCount()
+        },
+        entities: {
+          count: await this.getEntitiesCount()
+        }
+      },
+      qna: {
+        count: await this.getQnaCount()
+      },
+      hooks: {
+        global: {
+          count: await this.getGlobalHooksCount()
+        }
+      },
+      actions: {
+        global: {
+          count: await this.getGlobalActionsCount()
+        },
+        bot: {
+          count: await this.getBotActionsCount()
+        }
+      },
+      contentElements: {
+        count: await this.cmsService.countContentElements()
+      },
+      users: {
+        superAdmins: {
+          count: config.superAdmins.length
+        },
+        collaborators: {
+          count: await this.getCollaboratorsCount()
+        },
+        chat: {
+          count: await this.userRepository.getUserCount()
+        }
+      },
+      auth: {
+        strategies: {
+          count: Object.keys(config.authStrategies).length
+        }
+      }
+    }
+  }
+
+  protected async getServerStats() {
+    return {
+      isProduction: process.IS_PRODUCTION,
+      externalUrl: process.EXTERNAL_URL,
+      botpressVersion: process.BOTPRESS_VERSION,
+      clusterEnabled: yn(process.CLUSTER_ENABLED, { default: false }),
+      os: process.platform,
+      bpfsStorage: process.BPFS_STORAGE,
+      dbType: this.database.knex.isLite ? 'sqlite' : 'postgres',
+      machineUUID: await machineUUID(),
+      fingerprint: await this.getServerFingerprint(),
+      totalMemoryBytes: os.totalmem(),
+      uptime: Math.round(process.uptime()),
+      license: {
+        type: process.IS_PRO_ENABLED ? 'pro' : 'ce',
+        status: await this.getLicenseStatus()
+      }
+    }
+  }
+
+  private async getBotsCount(): Promise<number> {
+    return BotService.getMountedBots().length
+  }
+
+  private async getWorkspacesCount(): Promise<number> {
+    return (await this.workspaceService.getWorkspaces()).length
+  }
+
+  private async getPipelineStagesCount(): Promise<number> {
+    const workspaces = await this.workspaceService.getWorkspaces()
+    return workspaces.reduce((acc, workspace) => {
+      return acc + workspace.pipeline.length
+    }, 0)
+  }
+
+  private async getFlowCount(): Promise<number> {
+    return (await this.ghostService.bots().directoryListing('/', '*/flows/*.flow.json', '*/flows/error.flow.json'))
+      .length
+  }
+
+  private async getIntentsCount(): Promise<number> {
+    return (await this.ghostService.bots().directoryListing('/', '*/intents/*')).length
+  }
+
+  private async getEntitiesCount(): Promise<number> {
+    return (await this.ghostService.bots().directoryListing('/', '*/entities/*')).length
+  }
+
+  private async getQnaCount(): Promise<number> {
+    return (await this.ghostService.bots().directoryListing('/', '*/qna/*')).length
+  }
+
+  private async getGlobalHooksCount(): Promise<number> {
+    return (await this.ghostService.global().directoryListing('hooks', '*.js')).length
+  }
+
+  private async getGlobalActionsCount(): Promise<number> {
+    return (await this.ghostService.global().directoryListing('actions', '*.js')).length
+  }
+
+  private async getBotActionsCount(): Promise<number> {
+    return (await this.ghostService.bots().directoryListing('/', '*/actions/*')).length
+  }
+
+  private async getCollaboratorsCount(): Promise<number> {
+    return (await this.authService.getAllUsers()).length
+  }
+}

--- a/packages/runtime/src/runtime/telemetry/stats/roles-stats.ts
+++ b/packages/runtime/src/runtime/telemetry/stats/roles-stats.ts
@@ -1,0 +1,93 @@
+import { BUILTIN_MODULES } from 'common/defaults'
+import LicensingService from 'common/licensing-service'
+import { buildSchema } from 'common/telemetry'
+import { AuthRule, Workspace } from 'common/typings'
+import { GhostService } from 'core/bpfs'
+import Database from 'core/database'
+import { JobService } from 'core/distributed'
+import { calculateHash } from 'core/misc/utils'
+import { TYPES } from 'core/types'
+import { inject, injectable } from 'inversify'
+import _ from 'lodash'
+import ms from 'ms'
+
+import { TelemetryRepository } from '../telemetry-repository'
+import { REDACTED, TelemetryStats } from './telemetry-stats'
+
+const DEFAULT_ROLES = ['dev', 'admin', 'editor', 'agent']
+
+interface Role {
+  id: string
+  rules: AuthRule[]
+}
+
+interface WorkspacePayload {
+  id: string
+  roles: Role[]
+}
+
+const obsfuscateModule = rules => {
+  return rules.reduce((acc, rule) => {
+    const res = obfuscateRule(rule.res)
+    return [...acc, { ...rule, res }]
+  }, [])
+}
+
+const obfuscateRule = res => {
+  const regex = /^module\.([\w-]+)\.?/
+  const result = regex.exec(res)
+
+  if (!result) {
+    return res
+  }
+
+  return BUILTIN_MODULES.includes(result[1]) ? res : res.replace(result[1], REDACTED)
+}
+
+@injectable()
+export class RolesStats extends TelemetryStats {
+  protected interval: number
+  protected url: string
+  protected lock: string
+
+  constructor(
+    @inject(TYPES.GhostService) ghostService: GhostService,
+    @inject(TYPES.Database) database: Database,
+    @inject(TYPES.LicensingService) licenseService: LicensingService,
+    @inject(TYPES.JobService) jobService: JobService,
+    @inject(TYPES.TelemetryRepository) telemetryRepo: TelemetryRepository
+  ) {
+    super(ghostService, database, licenseService, jobService, telemetryRepo)
+    this.url = process.TELEMETRY_URL
+    this.lock = 'botpress:telemetry-custom-roles'
+    this.interval = ms('1d')
+  }
+
+  protected async getStats() {
+    return {
+      ...buildSchema(await this.getServerStats(), 'server'),
+      event_type: 'custom_roles',
+      event_data: { schema: '1.0.0', roles: await this.getWorkspacePayloads() }
+    }
+  }
+
+  private async getWorkspacePayloads(): Promise<WorkspacePayload[]> {
+    const workspaces = await this.getWorkspaceConfig()
+
+    return workspaces.reduce((acc, workspace) => {
+      const roles = workspace.roles.map(role => ({
+        id: _.includes(DEFAULT_ROLES, role.id) ? role.id : calculateHash(role.id),
+        rules: obsfuscateModule(role.rules)
+      }))
+      return [...acc, { id: calculateHash(workspace.id), roles }]
+    }, [] as WorkspacePayload[])
+  }
+
+  private async getWorkspaceConfig(): Promise<Workspace[]> {
+    try {
+      return await this.ghostService.global().readFileAsObject<Workspace[]>('/', 'workspaces.json')
+    } catch (error) {
+      return []
+    }
+  }
+}

--- a/packages/runtime/src/runtime/telemetry/stats/sdk-stats.ts
+++ b/packages/runtime/src/runtime/telemetry/stats/sdk-stats.ts
@@ -1,0 +1,192 @@
+import { parse } from '@babel/parser'
+import traverse from '@babel/traverse'
+import LicensingService from 'common/licensing-service'
+import { buildSchema } from 'common/telemetry'
+import { BotService } from 'core/bots'
+import { GhostService } from 'core/bpfs'
+import Database from 'core/database'
+import { JobService } from 'core/distributed'
+import { calculateHash } from 'core/misc/utils'
+import { TYPES } from 'core/types'
+import { inject, injectable } from 'inversify'
+import _ from 'lodash'
+import ms from 'ms'
+
+import { TelemetryRepository } from '../telemetry-repository'
+import { BotHooks, getHooksLifecycle, Hook } from './hooks-stats'
+import { TelemetryStats } from './telemetry-stats'
+
+const PARSE_CONFIG = { allowReturnOutsideFunction: true }
+
+interface UsageParams {
+  botId?: string
+  lifecycle?: string
+  enabled?: Boolean
+}
+
+interface Usage {
+  namespace: string
+  method: string
+  count: number
+}
+
+type ParsedFile = {
+  fileName: string
+  usages: Usage[]
+} & UsageParams
+
+interface SDKUsageEvent {
+  actions: SDKUsage
+  hooks: SDKUsage
+}
+
+interface SDKUsage {
+  global: ParsedFile[]
+  perBots: ParsedFile[]
+}
+
+@injectable()
+export class SDKStats extends TelemetryStats {
+  protected interval: number
+  protected url: string
+  protected lock: string
+
+  constructor(
+    @inject(TYPES.GhostService) ghostService: GhostService,
+    @inject(TYPES.Database) database: Database,
+    @inject(TYPES.LicensingService) licenseService: LicensingService,
+    @inject(TYPES.JobService) jobService: JobService,
+    @inject(TYPES.TelemetryRepository) telemetryRepo: TelemetryRepository
+  ) {
+    super(ghostService, database, licenseService, jobService, telemetryRepo)
+    this.url = process.TELEMETRY_URL
+    this.lock = 'botpress:telemetry-SDK'
+    this.interval = ms('1d')
+  }
+
+  protected async getStats() {
+    return {
+      ...buildSchema(await this.getServerStats(), 'server'),
+      event_type: 'sdk_usage',
+      event_data: { schema: '1.0.0', SDKMethods: await this.getSDKUsage() }
+    }
+  }
+
+  private async getSDKUsage(): Promise<SDKUsageEvent> {
+    const bots = BotService.getMountedBots()
+    return { actions: await this.getActionUsages(bots), hooks: await this.getHooksUsages() }
+  }
+
+  private async getActionUsages(bots: string[]): Promise<SDKUsage> {
+    const rootFolder = 'actions'
+    const globalActionsNames = (await this.ghostService.global().directoryListing('/', `${rootFolder}/*.js`)).map(
+      path => path?.split('/').pop() || ''
+    )
+
+    const reducer = async (parsedFilesAcc, botId) => {
+      try {
+        const botActionsNames = await this.ghostService.forBot(botId).directoryListing(`/${rootFolder}`, '*.js')
+        const parsedFiles = await Promise.map(botActionsNames, name =>
+          this.parseFile(name, `/${rootFolder}`, { botId })
+        )
+        return [...parsedFilesAcc, ...parsedFiles]
+      } catch (error) {
+        return [...parsedFilesAcc]
+      }
+    }
+
+    const global = await Promise.map(globalActionsNames, name => this.parseFile(name, `/${rootFolder}`))
+    const perBots = await Promise.reduce(bots, reducer, [] as ParsedFile[])
+
+    return { global, perBots }
+  }
+
+  private async getHooksUsages(): Promise<SDKUsage> {
+    const reducer = async (parsedFilesAcc, botHooks: BotHooks) => {
+      const { botId, hooks } = botHooks
+
+      try {
+        const parsedFiles = await this.parseHooks(
+          hooks.filter(hook => hook.type === 'custom'),
+          botId
+        )
+        return [...parsedFilesAcc, ...parsedFiles]
+      } catch (err) {
+        return []
+      }
+    }
+
+    const hooksPayload = await getHooksLifecycle(this.ghostService, false)
+    const global = await this.parseHooks(hooksPayload.global.filter(hook => hook.type === 'custom'))
+    const perBots = await Promise.reduce(hooksPayload.perBots, reducer, [] as ParsedFile[])
+
+    return { global, perBots }
+  }
+
+  private async parseHooks(hooks: Hook[], botId?: string): Promise<ParsedFile[]> {
+    return Promise.map(hooks, async hook => {
+      const { lifecycle, enabled, path } = hook
+      const usageParams: UsageParams = { lifecycle, enabled }
+
+      if (botId) {
+        usageParams.botId = botId
+      }
+
+      return this.parseFile(path!, '/hooks', usageParams)
+    })
+  }
+
+  private async parseFile(name: string, rootFolder: string, usageParams?: UsageParams): Promise<ParsedFile> {
+    const file = await this.readFileAsString(rootFolder, name, usageParams?.botId)
+    const functions = this.extractFunctions(parse(file, PARSE_CONFIG))
+    const fileName = calculateHash(name?.split('/').pop() || '')
+    const usage: ParsedFile = { fileName, usages: this.parseMethods(functions) }
+
+    if (usageParams?.botId) {
+      usageParams.botId = calculateHash(usageParams.botId)
+    }
+
+    return { ...usage, ...usageParams }
+  }
+
+  private parseMethods(methods: string[]): Usage[] {
+    const sdkMethods = _.countBy(methods.filter(method => method?.split('.')[0] === 'bp'))
+    return _.map(sdkMethods, (count, methodChain) => {
+      const [, ...namespace] = methodChain.split('.')
+      const method = namespace.pop() || ''
+      return { namespace: namespace.join('.') || '', method, count }
+    })
+  }
+
+  private extractFunctions(ast): string[] {
+    const functions: string[] = []
+
+    const findCallee = function(node) {
+      if (node.type === 'MemberExpression') {
+        return `${findCallee(node.object)}.${node.property.name}`
+      } else {
+        return node.name // breaks recursion
+      }
+    }
+
+    const enter = function(path) {
+      if (path.node.type === 'CallExpression') {
+        const callee = findCallee(path.node.callee)
+        functions.push(callee)
+      }
+    }
+
+    traverse(ast, { enter })
+
+    return functions
+  }
+
+  private async readFileAsString(rootFolder: string, fileName: string, botId?: string): Promise<string> {
+    try {
+      const ghost = botId ? this.ghostService.forBot(botId) : this.ghostService.global()
+      return await ghost.readFileAsString(rootFolder, fileName)
+    } catch (error) {
+      return ''
+    }
+  }
+}

--- a/packages/runtime/src/runtime/telemetry/stats/telemetry-stats.ts
+++ b/packages/runtime/src/runtime/telemetry/stats/telemetry-stats.ts
@@ -1,0 +1,92 @@
+import axios from 'axios'
+import LicensingService from 'common/licensing-service'
+import { machineUUID } from 'common/stats'
+import { ServerStats } from 'common/telemetry'
+import { GhostService } from 'core/bpfs'
+import Database from 'core/database'
+import { JobService } from 'core/distributed'
+import { TYPES } from 'core/types'
+import { inject, injectable } from 'inversify'
+import ms from 'ms'
+import yn from 'yn'
+
+import { TelemetryRepository } from '../telemetry-repository'
+
+const debug = DEBUG('telemetry')
+
+export const DEFAULT = '***default***'
+export const REDACTED = '***redacted***'
+
+@injectable()
+export abstract class TelemetryStats {
+  protected abstract url: string
+  protected abstract lock: string
+  protected abstract interval: number
+
+  constructor(
+    @inject(TYPES.GhostService) protected ghostService: GhostService,
+    @inject(TYPES.Database) protected database: Database,
+    @inject(TYPES.LicensingService) protected licenseService: LicensingService,
+    @inject(TYPES.JobService) private jobService: JobService,
+    @inject(TYPES.TelemetryRepository) private telemetryRepo: TelemetryRepository
+  ) {}
+
+  public start() {
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    this.run(this.lock, this.interval, this.url)
+
+    setInterval(this.run.bind(this, this.lock, this.interval, this.url), this.interval)
+  }
+
+  protected abstract getStats()
+
+  protected async run(lockResource: string, interval: number, url: string) {
+    const lock = await this.jobService.acquireLock(lockResource, interval - ms('1 minute'))
+    if (lock) {
+      debug('Acquired lock')
+      const stats = await this.getStats()
+      await this.sendStats(url, stats)
+    }
+  }
+
+  private async sendStats(url: string, stats) {
+    try {
+      debug('Sending stats: %o', JSON.stringify(stats))
+      await axios.post(url, stats)
+    } catch (err) {
+      if (url === process.TELEMETRY_URL) {
+        await this.telemetryRepo.insertPayload(stats.uuid, stats)
+      }
+    }
+  }
+
+  protected async getServerStats(): Promise<ServerStats> {
+    return {
+      isProduction: process.IS_PRODUCTION,
+      externalUrl: process.EXTERNAL_URL,
+      botpressVersion: process.BOTPRESS_VERSION,
+      clusterEnabled: yn(process.CLUSTER_ENABLED, { default: false }),
+      os: process.platform,
+      bpfsStorage: process.BPFS_STORAGE,
+      dbType: this.database.knex.isLite ? 'sqlite' : 'postgres',
+      machineUUID: await machineUUID(),
+      fingerprint: await this.getServerFingerprint(),
+      license: {
+        type: process.IS_PRO_ENABLED ? 'pro' : 'ce',
+        status: await this.getLicenseStatus()
+      }
+    }
+  }
+
+  protected async getServerFingerprint(): Promise<string | null> {
+    try {
+      return this.licenseService.getFingerprint('cluster_url')
+    } catch (err) {
+      return eval('null')
+    }
+  }
+
+  protected async getLicenseStatus(): Promise<string> {
+    return (await this.licenseService.getLicenseStatus()).status
+  }
+}

--- a/packages/runtime/src/runtime/telemetry/stats/telemetry.inversify.ts
+++ b/packages/runtime/src/runtime/telemetry/stats/telemetry.inversify.ts
@@ -1,0 +1,42 @@
+import { TYPES } from 'core/types'
+import { ContainerModule, interfaces } from 'inversify'
+
+import { ActionsStats } from './actions-stats'
+import { ConfigsStats } from './configs-stats'
+import { HooksStats } from './hooks-stats'
+import { LegacyStats } from './legacy-stats'
+import { RolesStats } from './roles-stats'
+import { SDKStats } from './sdk-stats'
+import { UserStats } from './user-stats'
+
+const ServicesContainerModule = new ContainerModule((bind: interfaces.Bind) => {
+  bind<ActionsStats>(TYPES.ActionStats)
+    .to(ActionsStats)
+    .inSingletonScope()
+
+  bind<LegacyStats>(TYPES.LegacyStats)
+    .to(LegacyStats)
+    .inSingletonScope()
+
+  bind<RolesStats>(TYPES.RolesStats)
+    .to(RolesStats)
+    .inSingletonScope()
+
+  bind<SDKStats>(TYPES.SDKStats)
+    .to(SDKStats)
+    .inSingletonScope()
+
+  bind<HooksStats>(TYPES.HooksStats)
+    .to(HooksStats)
+    .inSingletonScope()
+
+  bind<ConfigsStats>(TYPES.ConfigsStats)
+    .to(ConfigsStats)
+    .inSingletonScope()
+
+  bind<UserStats>(TYPES.UserStats)
+    .to(UserStats)
+    .inSingletonScope()
+})
+
+export const TelemetryContainerModules = [ServicesContainerModule]

--- a/packages/runtime/src/runtime/telemetry/stats/user-stats.ts
+++ b/packages/runtime/src/runtime/telemetry/stats/user-stats.ts
@@ -1,0 +1,47 @@
+import LicensingService from 'common/licensing-service'
+import { buildSchema } from 'common/telemetry'
+import { GhostService } from 'core/bpfs'
+import Database from 'core/database'
+import { JobService } from 'core/distributed'
+import { MessagingService } from 'core/messaging'
+import { TYPES } from 'core/types'
+import { inject, injectable } from 'inversify'
+import _ from 'lodash'
+import ms from 'ms'
+
+import { TelemetryRepository } from '../telemetry-repository'
+import { TelemetryStats } from './telemetry-stats'
+
+@injectable()
+export class UserStats extends TelemetryStats {
+  protected interval: number
+  protected url: string
+  protected lock: string
+
+  constructor(
+    @inject(TYPES.GhostService) ghostService: GhostService,
+    @inject(TYPES.Database) database: Database,
+    @inject(TYPES.LicensingService) licenseService: LicensingService,
+    @inject(TYPES.JobService) jobService: JobService,
+    @inject(TYPES.TelemetryRepository) telemetryRepo: TelemetryRepository,
+    @inject(TYPES.MessagingService) private messagingService: MessagingService
+  ) {
+    super(ghostService, database, licenseService, jobService, telemetryRepo)
+    this.url = process.TELEMETRY_URL
+    this.lock = 'botpress:telemetry-new-users'
+    this.interval = ms('5m')
+  }
+
+  protected async getStats() {
+    const newUsers = this.messagingService.getNewUsersCount({ resetCount: true })
+
+    return {
+      ...buildSchema(await this.getServerStats(), 'server'),
+      event_type: 'new_users',
+      event_data: {
+        schema: '1.0.0',
+        newUsers
+      }
+    }
+  }
+}

--- a/packages/runtime/src/runtime/telemetry/telemetry-repository.ts
+++ b/packages/runtime/src/runtime/telemetry/telemetry-repository.ts
@@ -1,0 +1,115 @@
+import { TelemetryEntry } from 'common/telemetry'
+import { ConfigProvider } from 'core/config'
+import Database from 'core/database'
+import { TYPES } from 'core/types'
+import { inject, injectable } from 'inversify'
+import _ from 'lodash'
+import moment from 'moment'
+
+const DEFAULT_ENTRIES_LIMIT = 1000
+
+@injectable()
+export class TelemetryRepository {
+  private readonly tableName = 'telemetry'
+
+  constructor(
+    @inject(TYPES.Database) private database: Database,
+    @inject(TYPES.ConfigProvider) private config: ConfigProvider
+  ) {}
+
+  async refreshAvailability(): Promise<void> {
+    const time = moment()
+      .subtract(5, 'minute')
+      .toDate()
+
+    const events = await this.database.knex
+      .from(this.tableName)
+      .select('uuid')
+      .where(this.database.knex.date.isBefore('lastChanged', time))
+
+    const uuIds = events.map(event => event.uuid)
+
+    await this.updateAvailability(uuIds, true)
+  }
+
+  async updateAvailability(uuIds: string[], status: boolean): Promise<void> {
+    if (!uuIds.length) {
+      return
+    }
+
+    await Promise.mapSeries(_.chunk(uuIds, 500), async uuIdChunk => {
+      await this.database
+        .knex(this.tableName)
+        .whereIn('uuid', uuIdChunk)
+        .update({
+          available: this.database.knex.bool.parse(status),
+          lastChanged: this.database.knex.date.now()
+        })
+    })
+  }
+
+  async pruneEntries(): Promise<void> {
+    const config = await this.config.getBotpressConfig()
+    const offset = config.telemetry?.entriesLimit ?? DEFAULT_ENTRIES_LIMIT
+
+    const uuIds = await this.database.knex
+      .from(this.tableName)
+      .select('uuid')
+      .orderBy('creationDate', 'desc')
+      .offset(offset)
+      .then(rows => rows.map(entry => entry.uuid))
+
+    return this.removeMany(uuIds)
+  }
+
+  async removeMany(uuIds: string[]): Promise<void> {
+    await Promise.mapSeries(_.chunk(uuIds, 500), async uuIdChunk => {
+      await this.database
+        .knex(this.tableName)
+        .whereIn('uuid', uuIdChunk)
+        .del()
+    })
+  }
+
+  async getEntries(): Promise<TelemetryEntry[]> {
+    const events = await this.database.knex
+      .from(this.tableName)
+      .select('*')
+      .where('available', this.database.knex.bool.true())
+      .limit(200)
+
+    if (events.length > 0) {
+      const uuIds = events.map(event => event.uuid)
+      await this.updateAvailability(uuIds, this.database.knex.bool.false())
+    }
+
+    return events.map(event => this.database.knex.json.get(event.payload))
+  }
+
+  async insertPayload(uuid: string, payload: JSON) {
+    await this.database.knex(this.tableName).insert({
+      uuid,
+      payload: this.database.knex.json.set(payload),
+      available: this.database.knex.bool.true(),
+      lastChanged: this.database.knex.date.now(),
+      creationDate: this.database.knex.date.now()
+    })
+
+    await this.pruneEntries()
+  }
+
+  async getEntry(uuid: string): Promise<TelemetryEntry> {
+    return this.database.knex
+      .from(this.tableName)
+      .select('*')
+      .where('uuid', uuid)
+      .first()
+  }
+
+  async removePayload(uuid: string): Promise<void> {
+    await this.database
+      .knex(this.tableName)
+      .where({ uuid })
+      .del()
+  }
+}

--- a/packages/runtime/src/runtime/telemetry/telemetry-router.ts
+++ b/packages/runtime/src/runtime/telemetry/telemetry-router.ts
@@ -1,0 +1,61 @@
+import * as sdk from 'botpress/sdk'
+import { CustomRouter } from 'core/routers/customRouter'
+import { AuthService, TOKEN_AUDIENCE, checkTokenHeader } from 'core/security'
+import { RequestHandler, Router } from 'express'
+import Joi from 'joi'
+
+import { TelemetryRepository } from './telemetry-repository'
+
+export class TelemetryRouter extends CustomRouter {
+  private checkTokenHeader: RequestHandler
+
+  constructor(
+    private logger: sdk.Logger,
+    private authService: AuthService,
+    private telemetryRepo: TelemetryRepository
+  ) {
+    super('Telemetry', logger, Router({ mergeParams: true }))
+    this.checkTokenHeader = checkTokenHeader(this.authService, TOKEN_AUDIENCE)
+    this.setupRoutes()
+  }
+
+  private setupRoutes() {
+    // TODO get server header
+    this.router.post(
+      '/feedback',
+      this.checkTokenHeader,
+      this.asyncMiddleware(async (req, res) => {
+        const { success, events } = req.body
+
+        await Joi.validate(
+          req.body,
+          Joi.object().keys({
+            success: Joi.boolean().required(),
+            events: Joi.array()
+              .items(Joi.string())
+              .required()
+          })
+        )
+
+        success
+          ? await this.telemetryRepo.removeMany(events)
+          : await this.telemetryRepo.updateAvailability(events, true)
+        res.sendStatus(200)
+      })
+    )
+
+    this.router.get(
+      '/events',
+      this.checkTokenHeader,
+      this.asyncMiddleware(async (req, res) => {
+        try {
+          const events = await this.telemetryRepo.getEntries()
+          res.send(events)
+        } catch (error) {
+          this.logger.warn('Error extracting entries from Telemetry database')
+          res.send([])
+        }
+      })
+    )
+  }
+}

--- a/packages/runtime/src/runtime/telemetry/telemetry-table.ts
+++ b/packages/runtime/src/runtime/telemetry/telemetry-table.ts
@@ -1,0 +1,19 @@
+import { Table } from 'core/database/interfaces'
+
+export class TelemetryTable extends Table {
+  name: string = 'telemetry'
+
+  async bootstrap() {
+    let created = false
+
+    await this.knex.createTableIfNotExists(this.name, table => {
+      table.uuid('uuid').notNullable()
+      table.json('payload').notNullable()
+      table.boolean('available').notNullable()
+      table.timestamp('lastChanged').notNullable()
+      table.timestamp('creationDate').notNullable()
+      created = true
+    })
+    return created
+  }
+}


### PR DESCRIPTION
Package is added but is not integrated yet. 

Considerations:
The `Controller` will pass an environment variable named `TELEMETRY_URL` pointing to the Api Gateway instance and prepending it with the adequate query params to identify the client app source allowing to differentiate telemetry source.